### PR TITLE
TT2-1978 Add alarms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ node_modules/
 !.yarn/sdks
 !.yarn/versions
 .integration.test*.env
+
+# IntelliJ
+.idea/*

--- a/template.yaml
+++ b/template.yaml
@@ -674,3 +674,84 @@ Resources:
       Action: lambda:InvokeFunction
       FunctionName: !GetAtt IntegrationTestsSqsOperationsFunctionNameParameter.Value
       Principal: !Ref TestRoleArn
+
+  ConfirmDownloadRequestLambdaFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      FilterPattern: 'Error while handling confirm download request'
+      LogGroupName: !Ref ConfirmDownloadFunctionLogs
+      MetricTransformations:
+        - MetricValue: '1'
+          MetricNamespace: TxMA/TICFIntegration/Logs
+          MetricName: 'ConfirmDownloadRequestLambdaMetric'
+
+  DownloadWarningLambdaFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      FilterPattern: 'Error while handling download warning request'
+      LogGroupName: !Ref DownloadWarningFunctionLogs
+      MetricTransformations:
+        - MetricValue: '1'
+          MetricNamespace: TxMA/TICFIntegration/Logs
+          MetricName: 'DownloadWarningLambdaMetric'
+
+  SendEmailRequestToNotifyLambdaFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      FilterPattern: 'requestNotSentToNotify'
+      LogGroupName: !Ref SendEmailRequestToNotifyLogs
+      MetricTransformations:
+        - MetricValue: '1'
+          MetricNamespace: TxMA/TICFIntegration/Logs
+          MetricName: 'SendEmailRequestToNotifyLambdaMetric'
+
+  ConfirmDownloadRequestLambdaAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmActions:
+        - !ImportValue txma-alarms-slack-alerts-BuildNotificationTopicArn
+      AlarmDescription: 'An alarm that is triggered by an error within the ConfirmDownloadRequestFunction lambda.'
+      AlarmName: !Sub ${AWS::StackName}-confirm-download-lambda-alarm
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      DatapointsToAlarm: 1
+      EvaluationPeriods: 1
+      MetricName: ConfirmDownloadRequestLambdaMetric
+      Namespace: TxMA/TICFIntegration/Logs
+      Period: 3600
+      Statistic: Sum
+      Threshold: 1
+      TreatMissingData: notBreaching
+
+  DownloadWarningLambdaAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmActions:
+        - !ImportValue txma-alarms-slack-alerts-BuildNotificationTopicArn
+      AlarmDescription: 'An alarm that is triggered by an error within the DownloadWarningFunction lambda.'
+      AlarmName: !Sub ${AWS::StackName}-download-warning-lambda-alarm
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      DatapointsToAlarm: 1
+      EvaluationPeriods: 1
+      MetricName: DownloadWarningLambdaMetric
+      Namespace: TxMA/TICFIntegration/Logs
+      Period: 3600
+      Statistic: Sum
+      Threshold: 1
+      TreatMissingData: notBreaching
+
+  SendEmailRequestToNotifyLambdaAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmActions:
+        - !ImportValue txma-alarms-slack-alerts-BuildNotificationTopicArn
+      AlarmDescription: 'An alarm that is triggered by an error with the event body or with trying to send the email in the SendEmailRequestToNotifyFunction lambda.'
+      AlarmName: !Sub ${AWS::StackName}-send-email-request-to-notify-lambda-alarm
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      DatapointsToAlarm: 1
+      EvaluationPeriods: 1
+      MetricName: SendEmailRequestToNotifyLambdaMetric
+      Namespace: TxMA/TICFIntegration/Logs
+      Period: 3600
+      Statistic: Sum
+      Threshold: 1
+      TreatMissingData: notBreaching


### PR DESCRIPTION
Ticket Number: [TT2-1978](https://govukverify.atlassian.net/browse/TT2-1978)  🎫
Documentation Link(s): [Confluence](https://govukverify.atlassian.net/wiki/spaces/TMA/pages/4295360647/Lambdas+across+TxMA#Repo%3A-txma-ticf-query-results-delivery) :books:

## :bulb: Description

Add alarms to lambdas as outlined in Confluence link. A separate PR will be needed to complete 1978 by adding canary deployments once we are happy with the alarms

## :sparkles: Changes Made

- Add IaC code for alarms

## :frame_with_picture: Screenshots (if applicable)

![image](https://github.com/user-attachments/assets/58c44ac0-fc67-48da-ae4f-8d6e791dda19)

## :white_tick: Documentation update

- Confluence link will need to be updated when this is merged

[TT2-1978]: https://govukverify.atlassian.net/browse/TT2-1978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ