### PR TITLE
DPT-2136 add Splunk log filters

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -187,7 +187,7 @@ Resources:
     Condition: CslsEgress
     Properties:
       LogGroupName: !Ref ResultsApiAccessLogs
-      FilterPattern: ''
+      FilterPattern: '{ $.level = * && $.level != %TRACE|DEBUG% }'
       DestinationArn: '{{resolve:ssm:CSLSLogsDestination}}'
 
   LambdaDeployRole:
@@ -330,7 +330,7 @@ Resources:
     Condition: CslsEgress
     Properties:
       LogGroupName: !Ref ConfirmDownloadFunctionLogs
-      FilterPattern: ''
+      FilterPattern: '{ $.level = * && $.level != %TRACE|DEBUG% }'
       DestinationArn: '{{resolve:ssm:CSLSLogsDestination}}'
 
   DownloadWarningFunction:
@@ -423,7 +423,7 @@ Resources:
     Condition: CslsEgress
     Properties:
       LogGroupName: !Ref DownloadWarningFunctionLogs
-      FilterPattern: ''
+      FilterPattern: '{ $.level = * && $.level != %TRACE|DEBUG% }'
       DestinationArn: '{{resolve:ssm:CSLSLogsDestination}}'
 
   SendEmailRequestToNotifyFunction:
@@ -541,7 +541,7 @@ Resources:
     Condition: CslsEgress
     Properties:
       LogGroupName: !Ref SendEmailRequestToNotifyLogs
-      FilterPattern: ''
+      FilterPattern: '{ $.level = * && $.level != %TRACE|DEBUG% }'
       DestinationArn: '{{resolve:ssm:CSLSLogsDestination}}'
 
   SendEmailQueue:
@@ -681,7 +681,7 @@ Resources:
     Condition: CslsEgress
     Properties:
       LogGroupName: !Ref GenerateDownloadFunctionLogs
-      FilterPattern: ''
+      FilterPattern: '{ $.level = * && $.level != %TRACE|DEBUG% }'
       DestinationArn: '{{resolve:ssm:CSLSLogsDestination}}'
 
   # Query results integration test resources


### PR DESCRIPTION
- **Ticket Number**: [#DPT-2136](https://govukverify.atlassian.net/browse/DPT-2136) :ticket: 

## :bulb: Description

Add filters to AWS log subscriptions to stop Lambda System logs and messages at DEBUG and TRACE level from being forwarded to Splunk

## :test_tube: Testing Instructions/Notes

Check the logs in CloudWatch And compare in Splunk. Lambda System logs (START, END, REPORT messages) should not be visible in splunk. We don't currently have any messages at Debug or Trace level.


