### PR TITLE
DPT-2766: Add STACK_NAME env variable to run script

### DIFF
--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -10,6 +10,8 @@
 # in the Dockerfile.
 cd /test-app || exit 1
 
+export STACK_NAME="${SAM_STACK_NAME}"
+
 if [ "$TEST_ENVIRONMENT" == "build" ]; then
   npm run test:integration
   TESTS_EXIT_CODE=$?


### PR DESCRIPTION
- **Ticket Number**: #[Your Ticket Number] DPT-2766

## :bulb: Description

Make STACK_NAME available to vitest globalSetup

## :sparkles: Changes Made

The integration and e2e test setup (setup.ts) reads process.env.STACK_NAME to construct SSM parameter paths. This value was only defined in the vitest test.env config option, which is injected into test worker processes — it is not available in the main process where globalSetup runs.

SAM_STACK_NAME is already exported by CodeBuild before run-tests.sh executes, so this change maps it to STACK_NAME at the point where the CI environment meets the test runner, making it available throughout the entire vitest process including globalSetup.
