### PR TITLE
DPT-3047: Fix SonarQube report not being generated

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,9 +5,11 @@ sonar.projectKey=txma-ticf-query-results-delivery
 sonar.projectName=txma-ticf-query-results-delivery
 sonar.projectVersion=1.0
 
-sonar.sources=src
+sonar.sources=src,common
+sonar.tests=src,common
+sonar.test.inclusions=**/*.test.ts
 sonar.sourceEncoding=UTF-8
 
-sonar.exclusions=src/**/*.test.ts,src/utils/tests/setup/testConstants.ts
+sonar.exclusions=**/*.test.ts,src/utils/tests/setup/testConstants.ts
 
 sonar.javascript.lcov.reportPaths=./coverage/lcov.info

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,8 +9,11 @@ export default defineConfig({
     setupFiles: ['./common/utils/tests/setup/testEnvVars.ts'],
     coverage: {
       provider: 'v8',
+      reporter: ['text', 'lcov'],
       include: ['src/**/*.ts', 'common/**/*.ts'],
       exclude: [
+        '**/node_modules/**',
+        '**/dist/**',
         '**/scripts/**',
         '**/interface/**',
         '**/interfaces/**',


### PR DESCRIPTION
- **Ticket Number**: :ticket:: https://govukverify.atlassian.net/browse/DPT-3047

## :bulb: Description

SonarQube reports were not being generated because some Jest configs were still in place. The fix resolves this issue

## :sparkles: Changes Made

- Added reporter: ['text', 'lcov'] 
- Added common to sonar.sources
- added sonar.tests and sonar.test.inclusions

## :test_tube: Testing Instructions/Notes

  `npm run test:cov`


